### PR TITLE
feat: Add auth api

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,14 +1,15 @@
-const bodyParser = require('body-parser');
 const cors = require('cors');
 const express = require('express');
 const mongoose = require('mongoose');
 require('dotenv').config();
 
+const routes = require('./routes/route');
+
 const app = express();
 
 app.use(cors());
-app.use(bodyParser.urlencoded({ extended: false }));
-app.use(bodyParser.json());
+app.use(express.json());
+app.use('/api', routes);
 
 const mongoUrl =
   process.env.NODE_ENV === 'production'
@@ -16,9 +17,7 @@ const mongoUrl =
     : process.env.LOCAL_DB_ADDRESS;
 
 mongoose
-  .connect(mongoUrl, {
-    useNewUrlParser: true,
-  })
+  .connect(mongoUrl)
   .then(() => console.log('Connected to Database:', mongoUrl))
   .catch((error) => console.log('Error connecting to Database:', error));
 

--- a/controllers/auth.controller.js
+++ b/controllers/auth.controller.js
@@ -1,0 +1,114 @@
+const bcrypt = require('bcryptjs');
+
+const User = require('../models/User');
+
+const authController = {};
+
+// 회원가입
+authController.register = async (req, res) => {
+  try {
+    const { name, email, password } = req.body;
+
+    // 1) 필수값 검증
+    if (!email || !password || !name) {
+      return res.status(400).json({
+        error: 'VALIDATION_ERROR',
+        message: 'email, password, name 은 필수입니다.',
+      });
+    }
+
+    // 2) 이메일 중복 확인
+    const existing = await User.findOne({ email }).lean();
+    if (existing) {
+      return res.status(409).json({
+        error: 'DUPLICATE_EMAIL',
+        message: '이미 사용 중인 이메일입니다.',
+      });
+    }
+
+    // 3) 비밀번호 해싱
+    const salt = await bcrypt.genSalt(10);
+    const hashedPassword = await bcrypt.hash(password, salt);
+
+    // 4) 유저 생성
+    const user = await User.create({
+      name,
+      email,
+      password: hashedPassword,
+    });
+
+    // 5) 성공 응답
+    return res.status(201).json({
+      message: '회원가입 성공',
+      user,
+    });
+  } catch (error) {
+    console.log(error);
+
+    // DB unique 에러 (MongoDB E11000 duplicate key)
+    if (error.code === 11000) {
+      return res.status(409).json({
+        error: 'DUPLICATE_EMAIL',
+        message: '이미 사용 중인 이메일입니다.',
+      });
+    }
+
+    // 예상치 못한 에러
+    return res.status(500).json({
+      error: 'SERVER_ERROR',
+      message: '회원가입 중 문제가 발생했습니다.',
+    });
+  }
+};
+
+// 로그인
+authController.login = async (req, res) => {
+  try {
+    const { email, password } = req.body;
+
+    // 1) 필수값 검증
+    if (!email || !password) {
+      return res.status(400).json({
+        error: 'VALIDATION_ERROR',
+        message: 'email, password 는 필수입니다.',
+      });
+    }
+
+    // 2) 사용자 조회
+    const user = await User.findOne({ email });
+    if (!user) {
+      return res.status(401).json({
+        error: 'INVALID_CREDENTIALS',
+        message: '이메일 또는 비밀번호가 올바르지 않습니다.',
+      });
+    }
+
+    // 3) 비밀번호 검증
+    const isMatch = await bcrypt.compare(password, user.password);
+    if (!isMatch) {
+      return res.status(401).json({
+        error: 'INVALID_CREDENTIALS',
+        message: '이메일 또는 비밀번호가 올바르지 않습니다.',
+      });
+    }
+
+    // 4) JWT 토큰 생성
+    const token = await user.generateAuthToken();
+
+    // 5) 성공 응답
+    return res.status(200).json({
+      message: '로그인 성공',
+      user,
+      token,
+    });
+  } catch (err) {
+    console.error(err);
+
+    return res.status(500).json({
+      error: 'SERVER_ERROR',
+      message: '로그인 처리 중 문제가 발생했습니다.',
+    });
+  }
+};
+
+module.exports = authController;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "body-parser": "^2.2.0",
+        "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
@@ -517,6 +517,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "body-parser": "^2.2.0",
+    "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",

--- a/routes/auth.api.js
+++ b/routes/auth.api.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+
+const authController = require('../controllers/auth.controller');
+
+// 회원가입
+router.post('/register', authController.register);
+// 로그인
+router.post('/login', authController.login);
+
+module.exports = router;

--- a/routes/route.js
+++ b/routes/route.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+
+const authRouter = require('./auth.api');
+
+router.use('/auth', authRouter);
+
+module.exports = router;

--- a/utils/validator.js
+++ b/utils/validator.js
@@ -1,0 +1,14 @@
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,20}$/; // 영문 + 숫자 반드시 포함, 길이 8~20자 (특수문자는 허용 X)
+
+const validator = {};
+
+validator.validateEmail = (email) => {
+  return emailRegex.test(email);
+};
+
+validator.validatePassword = (password) => {
+  return passwordRegex.test(password);
+};
+
+module.exports = validator;


### PR DESCRIPTION
# Pull Request 제목: 
feat: Add auth api

## 변경 사항 요약
- 회원가입 / 로그인 API 구현
- 이메일 및 비밀번호 서버 단 Validation 추가
- bodyparsor 의존성 삭제 (exporess.json 대체)

## 상세 설명
- 회원가입
  - 이메일 형식 검증 (validateEmail)
  - 비밀번호 검증 (validatePassword: 8~20자, 영문+숫자)
  - bcrypt로 비밀번호 해싱
- 로그인
  - bcrypt로 비밀번호 검증
  - JWT 토큰 발급 (user.generateAuthToken())
 
## 기타 참고 사항
- 자세한 API 요청/응답 문서는 노션 참고바랍니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 사용자 회원가입·로그인 기능 추가로 계정 생성과 인증이 가능해졌습니다.
  - 로그인 성공 시 액세스 토큰이 발급됩니다.

- 리팩터링
  - 서버가 Express 내장 JSON 파서를 사용하도록 전환해 요청 처리 안정성을 개선했습니다.
  - 라우팅 구조를 정리해 인증 관련 엔드포인트를 일관된 경로로 제공하도록 구성했습니다.

- 잡무(Chores)
  - 의존성 업데이트: body-parser 제거, bcryptjs 추가.
  - 데이터베이스 연결 구성을 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->