### PR TITLE
Refactor/note controller

### DIFF
--- a/controllers/note.controller.js
+++ b/controllers/note.controller.js
@@ -109,12 +109,24 @@ noteController.updateNote = async (req, res) => {
       });
     }
 
-    // 부분 업데이트
     if (title !== undefined) note.title = title;
     if (content !== undefined) note.content = content;
     if (images !== undefined) note.images = images;
     if (category !== undefined) note.category = category;
-    if (completion !== undefined) note.completion = completion;
+
+    if (completion !== undefined) {
+      if (!note.completion) {
+        note.completion = {};
+      }
+
+      const wasCompleted = note.completion.isCompleted;
+
+      Object.assign(note.completion, completion);
+
+      if (completion.isCompleted !== undefined && completion.isCompleted !== wasCompleted) {
+        note.completion.completedAt = completion.isCompleted ? new Date() : undefined;
+      }
+    }
 
     await note.save();
 
@@ -157,7 +169,7 @@ noteController.deleteNote = async (req, res) => {
 };
 
 // 히트맵
-noteController.getNotesStatus = async (req, res) => {
+noteController.getNotesStatics = async (req, res) => {
   try {
     const userId = req.userId;
     const { year, month } = req.query;

--- a/controllers/note.controller.js
+++ b/controllers/note.controller.js
@@ -38,7 +38,7 @@ noteController.create = async (req, res) => {
 
 // 노트 목록 조회
 noteController.getNotes = async (req, res) => {
-  const { category, isCompleted } = req.query;
+  const { category } = req.query;
   const userId = req.userId;
 
   try {
@@ -46,10 +46,6 @@ noteController.getNotes = async (req, res) => {
 
     if (category) {
       query['category.name'] = category;
-    }
-
-    if (isCompleted !== undefined) {
-      query['completion.isCompleted'] = isCompleted === 'true';
     }
 
     const notes = await Note.find(query).sort({ createdAt: -1 }).lean();

--- a/controllers/note.controller.js
+++ b/controllers/note.controller.js
@@ -81,7 +81,7 @@ noteController.getNote = async (req, res) => {
       message: '노트를 조회했습니다.',
       note,
     });
-  } catch (error) {
+  } catch {
     return res.status(400).json({
       error: 'INVALID_ID',
       message: '올바르지 않은 노트 ID입니다.',
@@ -115,13 +115,12 @@ noteController.updateNote = async (req, res) => {
         note.completion = {};
       }
 
-      const wasCompleted = note.completion.isCompleted;
-
-      Object.assign(note.completion, completion);
-
-      if (completion.isCompleted !== undefined && completion.isCompleted !== wasCompleted) {
-        note.completion.completedAt = completion.isCompleted ? new Date() : undefined;
+      const sanitizedCompletion = { ...completion };
+      if (Object.prototype.hasOwnProperty.call(sanitizedCompletion, 'completedAt')) {
+        delete sanitizedCompletion.completedAt;
       }
+
+      Object.assign(note.completion, sanitizedCompletion);
     }
 
     await note.save();
@@ -156,7 +155,7 @@ noteController.deleteNote = async (req, res) => {
     return res.status(200).json({
       message: '노트가 삭제되었습니다.',
     });
-  } catch (error) {
+  } catch {
     return res.status(400).json({
       error: 'INVALID_ID',
       message: '올바르지 않은 노트 ID입니다.',

--- a/routes/note.api.js
+++ b/routes/note.api.js
@@ -7,7 +7,7 @@ const noteController = require('../controllers/note.controller');
 router.post('/', authController.authenticate, noteController.create);
 router.get('/', authController.authenticate, noteController.getNotes);
 
-router.get('/status', authController.authenticate, noteController.getNotesStatics);
+router.get('/statics', authController.authenticate, noteController.getNotesStatics);
 
 router.get('/:id', authController.authenticate, noteController.getNote);
 router.put('/:id', authController.authenticate, noteController.updateNote);

--- a/routes/note.api.js
+++ b/routes/note.api.js
@@ -7,7 +7,7 @@ const noteController = require('../controllers/note.controller');
 router.post('/', authController.authenticate, noteController.create);
 router.get('/', authController.authenticate, noteController.getNotes);
 
-router.get('/status', authController.authenticate, noteController.getNotesStatus);
+router.get('/status', authController.authenticate, noteController.getNotesStatics);
 
 router.get('/:id', authController.authenticate, noteController.getNote);
 router.put('/:id', authController.authenticate, noteController.updateNote);


### PR DESCRIPTION
# Pull Request 제목
note controller 및 router 수정

## 변경 사항 요약
- status -> statics로 rename
- get notes 내 사용하지 않는 필드 제거




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 완료 상태 전환 시 완료 일시(completedAt)를 자동으로 설정/해제합니다.
- 리팩터
  - 노트 통계 조회 엔드포인트를 /status에서 /statics로 변경했습니다.
  - 노트 목록 조회에서 완료 여부(isCompleted) 쿼리 필터를 제거하고 카테고리 필터만 지원합니다.
  - 완료 상태 업데이트를 전체 대체에서 병합 기반으로 전환하고, 들어오는 완료 정보에서 completedAt을 무시하도록 처리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->